### PR TITLE
feat: add search filters to github extras extension

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,12 @@
         }
       }
     ],
+    "searchFilters": [
+      {
+        "name": "type:issue",
+        "value": "type:issue"
+      }
+    ],
     "menus": {
       "directory/page": [
         {
@@ -45,7 +51,9 @@
             "type": "string",
             "pattern": "^[^/]+/[^/]+$"
           },
-          "default":["sourcegraph/sourcegraph"],
+          "default": [
+            "sourcegraph/sourcegraph"
+          ],
           "examples": [
             [
               "facebook/react",


### PR DESCRIPTION
Adds a `type: issue` filter to the filters bar in the `Search Results` page when this PR is merged: https://github.com/sourcegraph/sourcegraph/pull/999. 
Contributes to: https://github.com/sourcegraph/sourcegraph/issues/962